### PR TITLE
feat: add addition functionality to the string calculator app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Run Tests
+
+on: push
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    env:
+      DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run unit tests
+        run: |
+          yarn test
+          curl https://deepsource.io/cli | sh 
+          ./bin/deepsource report --analyzer test-coverage --key javascript --value-file ./coverage/lcov.info

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  collectCoverage: true
+};

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.3"
+  },
+  "scripts": {
+    "test": "yarn jest"
   }
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -1,0 +1,3 @@
+export function add(numbers: string): number {
+  return 0;
+}

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -4,6 +4,6 @@
  * @returns the sum of given numbers
  */
 export function add(numbers: string): number {
-  const numbersToAdd = numbers.split(',').map(number => Number(number));
+  const numbersToAdd = numbers.split(/,|\n/).map(number => Number(number));
   return numbersToAdd.reduce((sum, number) => sum + number, 0)
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -13,17 +13,7 @@ function getCustomSeparator(numbers: string, customSeparatorIdentifier: string) 
     return null;
   }
 
-  const [customSeparatorLine, numbersLine] = numbers.split('\n');
-
-  /**
-   * If the length of separator line is same as custom identifier length, then there is no separator.
-   * If the numbersLine is undefined, it means there was no `\n` in the string and hence no numbers to add.
-   * Note: we would still consider no numbers after a `\n` since that is essentially an empty string.
-   */
-  if (customSeparatorLine.length === customSeparatorIdentifierLength && numbersLine === undefined) {
-    return null;
-  }
-
+  const customSeparatorLine = numbers.split('\n')[0];
   return customSeparatorLine.substring(customSeparatorIdentifierLength);
 }
 

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -1,12 +1,9 @@
+/**
+ * Adds the given sequence of numbers
+ * @param numbers a comma-separated string of numbers
+ * @returns the sum of given numbers
+ */
 export function add(numbers: string): number {
-  if (numbers.length === 3) {
-    const [firstNumber, secondNumber] = numbers.split(',');
-    return Number(firstNumber) + Number(secondNumber);
-  }
-
-  if (numbers.length === 1) {
-    return Number(numbers);
-  }
-
-  return 0;
+  const numbersToAdd = numbers.split(',').map(number => Number(number));
+  return numbersToAdd.reduce((sum, number) => sum + number, 0)
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -42,11 +42,11 @@ export function add(numbers: string): number {
   }
 
   const numbersToAdd = numbers.split(separator).map(number => Number(number));
-  return numbersToAdd.reduce((sum, number) => {
-    if (number < 0) {
-      throw new Error(`negatives not allowed, found ${number}`)
-    }
+  const negativeNumbers = numbersToAdd.filter(number => number < 0);
 
-    return sum + number;
-  }, 0);
+  if (negativeNumbers.length > 0) {
+    throw new Error(`negatives not allowed, found ${negativeNumbers.join(',')}`)
+  }
+
+  return numbersToAdd.reduce((sum, number) => sum + number, 0);
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -42,5 +42,11 @@ export function add(numbers: string): number {
   }
 
   const numbersToAdd = numbers.split(separator).map(number => Number(number));
-  return numbersToAdd.reduce((sum, number) => sum + number, 0);
+  return numbersToAdd.reduce((sum, number) => {
+    if (number < 0) {
+      throw new Error(`negatives not allowed, found ${number}`)
+    }
+
+    return sum + number;
+  }, 0);
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -1,4 +1,9 @@
 export function add(numbers: string): number {
+  if (numbers.length === 3) {
+    const [firstNumber, secondNumber] = numbers.split(',');
+    return Number(firstNumber) + Number(secondNumber);
+  }
+
   if (numbers.length === 1) {
     return Number(numbers);
   }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -4,6 +4,17 @@
  * @returns the sum of given numbers
  */
 export function add(numbers: string): number {
-  const numbersToAdd = numbers.split(/,|\n/).map(number => Number(number));
-  return numbersToAdd.reduce((sum, number) => sum + number, 0)
+  let separator: RegExp | string = /,|\n/;
+
+  if (numbers.startsWith("//")) {
+    const [separatorLine, numbersLine] = numbers.split('\n');
+
+    if (separatorLine && numbersLine) {
+      separator = separatorLine.substring(2);
+      numbers = numbersLine;
+    }
+  }
+
+  const numbersToAdd = numbers.split(separator).map(number => Number(number));
+  return numbersToAdd.reduce((sum, number) => sum + number, 0);
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -1,3 +1,7 @@
 export function add(numbers: string): number {
+  if (numbers.length === 1) {
+    return Number(numbers);
+  }
+
   return 0;
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -1,18 +1,44 @@
 /**
+ * Extracts and returns the custom separator from a string of numbers, identified by a custom separator identifier.
+ * If the string does not start with the custom separator identifier or if there is no custom separator, returns null.
+ *
+ * @param {string} numbers - The string containing numbers, possibly preceded by a custom separator.
+ * @param {string} customSeparatorIdentifier - The identifier marking the start of the custom separator.
+ * @returns {string | null} The extracted custom separator, or null if not present or invalid.
+ */
+function getCustomSeparator(numbers: string, customSeparatorIdentifier: string) {
+  const customSeparatorIdentifierLength = customSeparatorIdentifier.length
+
+  if (!numbers.startsWith(customSeparatorIdentifier)) {
+    return null;
+  }
+
+  const [customSeparatorLine, numbersLine] = numbers.split('\n');
+
+  /**
+   * If the length of separator line is same as custom identifier length, then there is no separator.
+   * If the numbersLine is undefined, it means there was no `\n` in the string and hence no numbers to add.
+   * Note: we would still consider no numbers after a `\n` since that is essentially an empty string.
+   */
+  if (customSeparatorLine.length === customSeparatorIdentifierLength && numbersLine === undefined) {
+    return null;
+  }
+
+  return customSeparatorLine.substring(customSeparatorIdentifierLength);
+}
+
+/**
  * Adds the given sequence of numbers
  * @param numbers a comma-separated string of numbers
  * @returns the sum of given numbers
  */
 export function add(numbers: string): number {
   let separator: RegExp | string = /,|\n/;
+  const customSeparator = getCustomSeparator(numbers, "//");
 
-  if (numbers.startsWith("//")) {
-    const [separatorLine, numbersLine] = numbers.split('\n');
-
-    if (separatorLine && numbersLine) {
-      separator = separatorLine.substring(2);
-      numbers = numbersLine;
-    }
+  if (customSeparator) {
+    numbers = numbers.split('\n')[1];
+    separator = customSeparator;
   }
 
   const numbersToAdd = numbers.split(separator).map(number => Number(number));

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -1,0 +1,6 @@
+describe('The string calculator', () => {
+  test('should return zero for an empty string', () => {
+    const result = add("");
+    expect(result).toBe(0);
+  })
+})

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -1,13 +1,18 @@
 import { add } from "../src/string-calculator";
 
 describe('The string calculator', () => {
-  test('should return zero for an empty string', () => {
+  test('should return zero for an empty input string', () => {
     const result = add("");
     expect(result).toBe(0);
   })
 
-  test('should return the same number if the string only has a single number', () => {
+  test('should return the same number if the input string only has a single number', () => {
     const result = add("1");
     expect(result).toBe(1);
+  })
+
+  test('should return the sum of two numbers if the input string has two comma-separated numbers', () => {
+    const result = add("1,2");
+    expect(result).toBe(3);
   })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -1,3 +1,5 @@
+import { add } from "../src/string-calculator";
+
 describe('The string calculator', () => {
   test('should return zero for an empty string', () => {
     const result = add("");

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -25,4 +25,9 @@ describe('The string calculator', () => {
     const result = add("1\n2,3");
     expect(result).toBe(6);
   })
+
+  test('should return the sum of all numbers if the input string has a custom separator', () => {
+    const result = add("//;\n1;2");
+    expect(result).toBe(3);
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -30,4 +30,9 @@ describe('The string calculator', () => {
     const result = add("//;\n1;2");
     expect(result).toBe(3);
   })
+
+  test('should return zero if there are no numbers, i.e empty string in the line after custom separator', () => {
+    const result = add("//;\n");
+    expect(result).toBe(0);
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -20,4 +20,9 @@ describe('The string calculator', () => {
     const result = add("1,2,3");
     expect(result).toBe(6);
   })
+
+  test('should return the sum of all numbers if the input string has newline and comma separators', () => {
+    const result = add("1\n2,3");
+    expect(result).toBe(6);
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -5,4 +5,9 @@ describe('The string calculator', () => {
     const result = add("");
     expect(result).toBe(0);
   })
+
+  test('should return the same number if the string only has a single number', () => {
+    const result = add("1");
+    expect(result).toBe(1);
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -15,4 +15,9 @@ describe('The string calculator', () => {
     const result = add("1,2");
     expect(result).toBe(3);
   })
+
+  test('should return the sum of all numbers if the input string has more than two comma-separated numbers', () => {
+    const result = add("1,2,3");
+    expect(result).toBe(6);
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -35,4 +35,8 @@ describe('The string calculator', () => {
     const result = add("//;\n");
     expect(result).toBe(0);
   })
+
+  test('should throw an error with the negative number in message if a negative number is passed as input', () => {
+    expect(() => add("1,-2")).toThrow("negatives not allowed, found -2");
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -39,4 +39,8 @@ describe('The string calculator', () => {
   test('should throw an error with the negative number in message if a negative number is passed as input', () => {
     expect(() => add("1,-2")).toThrow("negatives not allowed, found -2");
   })
+
+  test('should throw an error with all the negative numbers in message if negative numbers are passed as input', () => {
+    expect(() => add("1,-2,2,-4")).toThrow("negatives not allowed, found -2,-4");
+  })
 })


### PR DESCRIPTION
Handles the following cases:

1. Create a simple String calculator with a method signature:

int Add(string numbers)
The method can take up to two numbers, separated by commas, and will return their sum.

For example "" or "1" or "1,2" as inputs. (for an empty string it will return 0)

Hints:
- Start with the simplest test case of an empty string and move to one and two numbers
- Remember to solve things as simply as possible so that you force yourself to write tests you did not think about
- Remember to refactor after each passing test
- Allow the Add method to handle an unknown amount of numbers

2. Allow the Add method to handle new lines between numbers (instead of commas).

The following input is ok: "1\n2,3" (will equal 6)
The following input is NOT ok: "1,\n" (not need to prove it - just clarifying)

3. Support different delimiters

To change a delimiter, the beginning of the string will contain a separate line that looks like this: "//[delimiter]\n[numbers…]" for example "//;\n1;2" should return three where the default delimiter is ";"
The first line is optional. all existing scenarios should still be supported

4. Calling Add with a negative number will throw an exception "negatives not allowed" - and the negative that was passed.

If there are multiple negatives, show all of them in the exception message.

