### PR TITLE
feat: add more complex abilities to the string calculator

### DIFF
--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -38,5 +38,5 @@ export function add(numbers: string): number {
     throw new Error(`negatives not allowed, found ${negativeNumbers.join(',')}`)
   }
 
-  return numbersToAdd.reduce((sum, number) => sum + number, 0);
+  return numbersToAdd.reduce((sum, number) => sum += number <= 1000 ? number : 0, 0);
 }

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -14,6 +14,18 @@ function getCustomSeparator(numbers: string, customSeparatorIdentifier: string) 
   }
 
   const customSeparatorLine = numbers.split('\n')[0];
+  const regex = /\[([^\]]*)\]/;
+  const match = regex.exec(customSeparatorLine);
+
+  /**
+   * If the separator has content of the format [***],
+   * we use regex to fetch the separator that is between the square brackets.
+   */
+  if (match && match[1]) {
+    return match[1];
+  }
+
+  // If [***] is not present, we consider only a single separator to be present.
   return customSeparatorLine.substring(customSeparatorIdentifierLength);
 }
 

--- a/src/string-calculator.ts
+++ b/src/string-calculator.ts
@@ -1,26 +1,18 @@
 /**
- * Extracts and returns the custom separator from a string of numbers, identified by a custom separator identifier.
- * If the string does not start with the custom separator identifier or if there is no custom separator, returns null.
+ * Extracts multiple custom separators from a custom separator line and returns either a single string
+ * or a regular expression that matches any of the extracted separators.
  *
- * @param {string} numbers - The string containing numbers, possibly preceded by a custom separator.
- * @param {string} customSeparatorIdentifier - The identifier marking the start of the custom separator.
- * @returns {string | null} The extracted custom separator, or null if not present or invalid.
+ * @param {string} customSeparatorLine - The line containing custom separators enclosed in square brackets.
+ * @returns {string | RegExp | null} The extracted separator(s) as a string, a regular expression, or null if no separator is found.
  */
-function getCustomSeparator(numbers: string, customSeparatorIdentifier: string): string | RegExp | null {
-  const customSeparatorIdentifierLength = customSeparatorIdentifier.length
-
-  if (!numbers.startsWith(customSeparatorIdentifier)) {
-    return null;
-  }
-
-  const customSeparatorLine = numbers.split('\n')[0];
+function getCustomMultiCharSeparator(customSeparatorLine: string) {
   const regex = /\[([^\]]*)\]/g;
   const matchedSeparators: string[] = [];
   let match: RegExpExecArray | null = null;
 
   while ((match = regex.exec(customSeparatorLine)) !== null) {
     if (match[1]) {
-      matchedSeparators.push(match[1])
+      matchedSeparators.push(match[1]);
     }
   }
 
@@ -36,8 +28,29 @@ function getCustomSeparator(numbers: string, customSeparatorIdentifier: string):
     return new RegExp(escapedSeparators);
   }
 
-  // If a format that looks like [***] is not present, we consider only a single separator to be present.
-  return customSeparatorLine.substring(customSeparatorIdentifierLength);
+  return null;
+}
+
+/**
+ * Extracts and returns the custom separator from a string of numbers, identified by a custom separator identifier.
+ * If the string does not start with the custom separator identifier or if there is no custom separator, returns null.
+ *
+ * @param {string} numbers - The string containing numbers, possibly preceded by a custom separator.
+ * @param {string} customSeparatorIdentifier - The identifier marking the start of the custom separator.
+ * @returns {string | null} The extracted custom separator, or null if not present or invalid.
+ */
+function getCustomSeparator(numbers: string, customSeparatorIdentifier: string): string | RegExp | null {
+  const customSeparatorIdentifierLength = customSeparatorIdentifier.length;
+
+  if (!numbers.startsWith(customSeparatorIdentifier)) {
+    return null;
+  }
+
+  const customSeparatorLine = numbers.split('\n')[0];
+  const customMultiCharSeparator = getCustomMultiCharSeparator(customSeparatorLine);
+
+  // If a custom multi char separator is not present, we consider only a single separator to be present.
+  return customMultiCharSeparator ?? customSeparatorLine.substring(customSeparatorIdentifierLength);
 }
 
 /**
@@ -58,7 +71,7 @@ export function add(numbers: string): number {
   const negativeNumbers = numbersToAdd.filter(number => number < 0);
 
   if (negativeNumbers.length > 0) {
-    throw new Error(`negatives not allowed, found ${negativeNumbers.join(',')}`)
+    throw new Error(`negatives not allowed, found ${negativeNumbers.join(',')}`);
   }
 
   return numbersToAdd.reduce((sum, number) => sum += number <= 1000 ? number : 0, 0);

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -44,8 +44,13 @@ describe('The string calculator', () => {
     expect(() => add("1,-2,2,-4")).toThrow("negatives not allowed, found -2,-4");
   })
 
-  test('should ignore numbers greater than 1000 in the input string', () => {
+  test('should return the sum after ignoring numbers greater than 1000 in the input string', () => {
     const result = add("1,1001")
     expect(result).toBe(1);
+  })
+
+  test('should return the sum of all numbers with separators having more than 1 char length', () => {
+    const result = add("//[***]\n1***2***3");
+    expect(result).toBe(6);
   })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -54,8 +54,13 @@ describe('The string calculator', () => {
     expect(result).toBe(6);
   })
 
-  test('should return the sum of all numbers with multiple separators having more than 1 char length', () => {
+  test('should return the sum of all numbers with multiple separators having 1 char length', () => {
     const result = add("//[*][%]\n1*2%3");
+    expect(result).toBe(6);
+  })
+
+  test('should return the sum of all numbers with multiple separators having more than 1 char length', () => {
+    const result = add("//[**][%%]\n1**2%%3");
     expect(result).toBe(6);
   })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -53,4 +53,9 @@ describe('The string calculator', () => {
     const result = add("//[***]\n1***2***3");
     expect(result).toBe(6);
   })
+
+  test('should return the sum of all numbers with multiple separators having more than 1 char length', () => {
+    const result = add("//[*][%]\n1*2%3");
+    expect(result).toBe(6);
+  })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -45,6 +45,7 @@ describe('The string calculator', () => {
   })
 
   test('should ignore numbers greater than 1000 in the input string', () => {
-    expect(() => add("1,1001")).toBe(1);
+    const result = add("1,1001")
+    expect(result).toBe(1);
   })
 })

--- a/tests/string-calculator.test.ts
+++ b/tests/string-calculator.test.ts
@@ -43,4 +43,8 @@ describe('The string calculator', () => {
   test('should throw an error with all the negative numbers in message if negative numbers are passed as input', () => {
     expect(() => add("1,-2,2,-4")).toThrow("negatives not allowed, found -2,-4");
   })
+
+  test('should ignore numbers greater than 1000 in the input string', () => {
+    expect(() => add("1,1001")).toBe(1);
+  })
 })


### PR DESCRIPTION
Takes care of the following:

1. Numbers bigger than 1000 should be ignored, so adding 2 + 1001 = 2
2. Delimiters can be of any length with the following format: “//[delimiter]\n” for example: “//[***]\n1***2***3” should return 6
3. Allow multiple delimiters like this: “//[delim1][delim2]\n” for example “//[*][%]\n1*2%3” should return 6.
make sure you can also handle multiple delimiters with length longer than one char